### PR TITLE
Refactor auth to use PostgreSQL

### DIFF
--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -41,6 +41,26 @@ class UserService {
   }
 
   /**
+   * Find a user by username
+   */
+  async findByUsername(username: string): Promise<User | null> {
+    return prisma.user.findUnique({
+      where: { username },
+    });
+  }
+
+  /**
+   * Find a user by either email or username
+   */
+  async findByEmailOrUsername(identifier: string): Promise<User | null> {
+    return prisma.user.findFirst({
+      where: {
+        OR: [{ email: identifier }, { username: identifier }],
+      },
+    });
+  }
+
+  /**
    * Find a user by provider and provider ID
    */
   async findByProvider(


### PR DESCRIPTION
## Summary
- switch register controller to Prisma and PostgreSQL user service
- update login controller to query PostgreSQL and store session token
- extend user service with helpers for username and identifier lookups

## Testing
- `yarn test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689de9abd2e083219c476cc20471ba79