### PR TITLE
refactor: migrate controllers to postgres services

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,7 @@ model Organization {
   bankAccounts BankAccount[]
   invoices     Invoice[]
   receipts     Receipt[]
+  paymentClaims PaymentClaim[]
   createdAt    DateTime             @default(now())
   updatedAt    DateTime             @updatedAt
 }
@@ -103,6 +104,7 @@ model Invoice {
   total         Float
   status        InvoiceStatus @default(SENT)
   receipts      Receipt[]
+  paymentClaims PaymentClaim[]
   createdAt     DateTime      @default(now())
   updatedAt     DateTime      @updatedAt
 
@@ -121,6 +123,28 @@ model Receipt {
   buyerName     String
   createdAt     DateTime    @default(now())
   updatedAt     DateTime    @updatedAt
+}
+
+model PaymentClaim {
+  id             String        @id @default(uuid())
+  organization   Organization  @relation(fields: [organizationId], references: [id])
+  organizationId String
+  invoice        Invoice       @relation(fields: [invoiceId], references: [id])
+  invoiceId      String
+  amountClaimed  Float
+  refText        String?
+  payerBank      String?
+  payerName      String?
+  proofFileUrl   String?
+  source         String        @default("buyer")
+  status         String        @default("pending")
+  approvedBy     String?
+  approvedAt     DateTime?
+  rejectedBy     String?
+  rejectedAt     DateTime?
+  rejectionReason String?
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 }
 
 model Lead {

--- a/src/controllers/google.controller.ts
+++ b/src/controllers/google.controller.ts
@@ -3,7 +3,6 @@ import { Request, Response } from 'express';
 import { Toolbox } from '../utils/tools';
 import { ResponseUtils } from '../utils/reponse';
 import { StatusCode } from '../types/response';
-import { mongoUserService } from '../service/mongo';
 import { UserProvider } from '../types';
 import axios from 'axios';
 class GoogleAuthController {

--- a/src/controllers/settings.controller.ts
+++ b/src/controllers/settings.controller.ts
@@ -1,50 +1,97 @@
-import { Request, Response } from 'express';
-import { Types } from 'mongoose';
-import OrgBankDetails from '../models/orgBankDetails.model';
-import Org from '../models/org.model';
+import { Response } from 'express';
+import { organizationService } from '../service/org.service';
+import { userService } from '../service/user.service';
 import { ResponseUtils } from '../utils/reponse';
 import { StatusCode } from '../types';
 
+type AuthenticatedRequest = import('../middleware/auth.middleware').AuthRequest;
+
 class SettingsCtrl {
-  static async getBankDetails(req: Request, res: Response): Promise<void> {
-    const orgIdHeader = req.header('x-org-id');
-    if (!orgIdHeader)
-      ResponseUtils.error(res, 'Missing X-Org-Id', StatusCode.BAD_REQUEST);
-    const orgId = new Types.ObjectId(orgIdHeader);
-    const bank = await OrgBankDetails.findOne({ orgId });
-    ResponseUtils.success(
-      res,
-      { bank },
-      'Bank details retrieved successfully',
-      StatusCode.OK
-    );
+  static async getBankDetails(
+    req: AuthenticatedRequest,
+    res: Response
+  ): Promise<void> {
+    const orgId = req.header('x-org-id');
+    if (!orgId) {
+      return ResponseUtils.error(res, 'Missing X-Org-Id', StatusCode.BAD_REQUEST);
+    }
+    try {
+      const org = await organizationService.findById(orgId);
+      if (!org) {
+        return ResponseUtils.error(
+          res,
+          'Organization not found',
+          StatusCode.NOT_FOUND
+        );
+      }
+      const bank = org.bankAccounts.find((b) => b.isDefault) || null;
+      ResponseUtils.success(
+        res,
+        { bank },
+        'Bank details retrieved successfully',
+        StatusCode.OK
+      );
+    } catch (e: any) {
+      ResponseUtils.error(res, e.message, StatusCode.INTERNAL_SERVER_ERROR);
+    }
   }
 
-  static async updateBankDetails(req: Request, res: Response): Promise<void> {
-    const orgIdHeader = req.header('x-org-id');
-    if (!orgIdHeader)
-      ResponseUtils.error(res, 'Missing X-Org-Id', StatusCode.BAD_REQUEST);
-    const orgId = new Types.ObjectId(orgIdHeader);
-    const update = { ...req.body, orgId };
-    const bank = await OrgBankDetails.findOneAndUpdate({ orgId }, update, {
-      upsert: true,
-      new: true,
-    });
-    res.json(bank);
+  static async updateBankDetails(
+    req: AuthenticatedRequest,
+    res: Response
+  ): Promise<void> {
+    const orgId = req.header('x-org-id');
+    if (!orgId) {
+      return ResponseUtils.error(res, 'Missing X-Org-Id', StatusCode.BAD_REQUEST);
+    }
+    const userId = req.user?.userId;
+    if (!userId) {
+      return ResponseUtils.error(res, 'User not authenticated', StatusCode.UNAUTHORIZED);
+    }
+    try {
+      const user = await userService.findByUserId(userId);
+      if (!user) {
+        return ResponseUtils.error(res, 'User not found', StatusCode.UNAUTHORIZED);
+      }
+      const bank = await organizationService.addBankAccount(orgId, req.body, user.id);
+      ResponseUtils.success(
+        res,
+        { bank },
+        'Bank details updated successfully',
+        StatusCode.OK
+      );
+    } catch (e: any) {
+      ResponseUtils.error(res, e.message, StatusCode.INTERNAL_SERVER_ERROR);
+    }
   }
 
-  static async updateOrgDetails(req: Request, res: Response): Promise<void> {
-    const orgIdHeader = req.header('x-org-id');
-    if (!orgIdHeader)
-      ResponseUtils.error(res, 'Missing X-Org-Id', StatusCode.BAD_REQUEST);
-    const orgId = new Types.ObjectId(orgIdHeader);
-    // for now, we assume owner is same as orgId for simplicity
-    const update = { ...req.body, orgId, owner: orgId };
-    const org = await Org.findOneAndUpdate({ _id: orgId }, update, {
-      upsert: true,
-      new: true,
-    });
-    res.json(org);
+  static async updateOrgDetails(
+    req: AuthenticatedRequest,
+    res: Response
+  ): Promise<void> {
+    const orgId = req.header('x-org-id');
+    if (!orgId) {
+      return ResponseUtils.error(res, 'Missing X-Org-Id', StatusCode.BAD_REQUEST);
+    }
+    const userId = req.user?.userId;
+    if (!userId) {
+      return ResponseUtils.error(res, 'User not authenticated', StatusCode.UNAUTHORIZED);
+    }
+    try {
+      const user = await userService.findByUserId(userId);
+      if (!user) {
+        return ResponseUtils.error(res, 'User not found', StatusCode.UNAUTHORIZED);
+      }
+      const org = await organizationService.update(orgId, req.body, user.id);
+      ResponseUtils.success(
+        res,
+        { org },
+        'Organization updated successfully',
+        StatusCode.OK
+      );
+    } catch (e: any) {
+      ResponseUtils.error(res, e.message, StatusCode.INTERNAL_SERVER_ERROR);
+    }
   }
 }
 

--- a/src/service/paymentClaim.service.ts
+++ b/src/service/paymentClaim.service.ts
@@ -1,0 +1,123 @@
+import { prisma, InvoiceStatus, Prisma } from '../lib/db/prisma';
+import { sendWhatsAppText, receiptService } from './receipt.service';
+
+export class PaymentClaimService {
+  async createClaim(data: {
+    orgId: string;
+    invoiceCode: string;
+    amount: number;
+    refText?: string;
+    payerBank?: string;
+    payerName?: string;
+    proofFileUrl?: string;
+    source?: string;
+  }) {
+    const {
+      orgId,
+      invoiceCode,
+      amount,
+      refText,
+      payerBank,
+      payerName,
+      proofFileUrl,
+      source = 'buyer',
+    } = data;
+
+    const invoice = await prisma.invoice.findFirst({
+      where: { organizationId: orgId, code: invoiceCode },
+    });
+    if (!invoice) {
+      throw new Error('Invoice not found');
+    }
+
+    return prisma.paymentClaim.create({
+      data: {
+        organizationId: orgId,
+        invoiceId: invoice.id,
+        amountClaimed: amount,
+        refText,
+        payerBank,
+        payerName,
+        proofFileUrl,
+        source,
+      },
+    });
+  }
+
+  async getPendingClaims(orgId: string) {
+    return prisma.paymentClaim.findMany({
+      where: { organizationId: orgId, status: 'pending' },
+      orderBy: { createdAt: 'desc' },
+      include: { invoice: true },
+    });
+  }
+
+  async approveClaim(data: {
+    id: string;
+    orgId: string;
+    approvedBy: string;
+  }) {
+    const { id, orgId, approvedBy } = data;
+    return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+      const claim = await tx.paymentClaim.findFirst({
+        where: { id, organizationId: orgId },
+        include: { invoice: true, organization: true },
+      });
+      if (!claim) {
+        throw new Error('Claim not found');
+      }
+
+      const updatedClaim = await tx.paymentClaim.update({
+        where: { id },
+        data: {
+          status: 'approved',
+          approvedBy,
+          approvedAt: new Date(),
+        },
+        include: { invoice: true, organization: true },
+      });
+
+      const invoice = await tx.invoice.update({
+        where: { id: claim.invoiceId },
+        data: { status: InvoiceStatus.PAID },
+        include: { organization: true },
+      });
+
+      const receipt = await receiptService.create({
+        orgId: invoice.organizationId,
+        invoiceId: invoice.id,
+        amount: invoice.total,
+        sellerName: invoice.organization.name,
+        buyerName: claim.payerName || 'Customer',
+      });
+
+      if (invoice.contactPhone) {
+        const receiptUrl = `${process.env.PUBLIC_APP_URL || ''}/api/invoices/receipts/${receipt.id}`;
+        const msg = `Payment Receipt: ${receipt.receiptNumber}\n\nYour payment of ₦${invoice.total} to ${invoice.organization.name} for invoice ${invoice.code} has been confirmed.\n\nView your receipt: ${receiptUrl}\n\nThank you for your business!`;
+        await sendWhatsAppText(invoice.contactPhone, msg);
+      }
+
+      return { claim: updatedClaim, invoice, receipt };
+    });
+  }
+
+  async rejectClaim(data: {
+    id: string;
+    orgId: string;
+    rejectedBy: string;
+    rejectionReason?: string;
+  }) {
+    const { id, orgId, rejectedBy, rejectionReason } = data;
+    return prisma.paymentClaim.update({
+      where: { id },
+      data: {
+        status: 'rejected',
+        rejectedBy,
+        rejectedAt: new Date(),
+        rejectionReason,
+      },
+    });
+  }
+}
+
+export const paymentClaimService = new PaymentClaimService();


### PR DESCRIPTION
## Summary
- replace remaining Mongo-based controllers with Prisma-backed services
- add Prisma lead service and update auth, settings, telegram, and WhatsApp flows
- stub unsupported invoice claim endpoints as not implemented
- implement Postgres-backed payment claim workflow and verification endpoints

## Testing
- `npm run build` *(fails: TS errors)*
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689eedb96fa08321981a78348406c362