### PR TITLE
feat: add whatsapp invoice bot

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,11 @@ enum InvoiceStatus {
   VOID
 }
 
+enum BotInvoiceStatus {
+  PENDING
+  PAID
+}
+
 // Models
 model User {
   id                    String               @id @default(uuid())
@@ -162,4 +167,15 @@ model WhatsAppConnection {
   updatedAt     DateTime @updatedAt
 
   @@unique([userId, wabaId, phoneNumberId])
+}
+
+model BotInvoice {
+  id            String           @id @default(uuid())
+  amount        Float
+  customerName  String
+  customerPhone String
+  status        BotInvoiceStatus @default(PENDING)
+  invoiceCode   String           @unique
+  paidAt        DateTime?
+  createdAt     DateTime         @default(now())
 }

--- a/src/controllers/whatsapp.controller.ts
+++ b/src/controllers/whatsapp.controller.ts
@@ -8,6 +8,13 @@ import { LeadLabel } from '../types/leads';
 import { mongoLeadService } from '../service/mongo';
 import { UserProvider, UserType } from '../types';
 import axios from 'axios';
+import {
+  createDraftInvoice,
+  listUnpaidInvoices,
+  markInvoicePaid,
+  markInvoicePaidByPhone,
+} from '../service/invoice.service';
+import { sendWhatsAppText } from '../service/receipt.service';
 declare module 'express-serve-static-core' {
   interface Request {
     rawBody?: Buffer;
@@ -86,7 +93,72 @@ class WhatsappController {
         }
 
         if (text) {
+          const trimmed = text.trim();
+          const upper = trimmed.toUpperCase();
+
           try {
+            if (upper.startsWith('NEW INVOICE')) {
+              const match = trimmed.match(/^NEW INVOICE\s+(\d+(?:\.\d+)?)\s+(.+)/i);
+              if (match) {
+                const amount = parseFloat(match[1]);
+                const customerName = match[2].trim();
+                const invoice = await createDraftInvoice({
+                  amount,
+                  customerName,
+                  customerPhone: userId,
+                });
+                await sendWhatsAppText(
+                  userId,
+                  `Draft invoice ${invoice.invoiceCode} created for ${invoice.customerName} with amount ${invoice.amount}.`
+                );
+              } else {
+                await sendWhatsAppText(
+                  userId,
+                  'Usage: NEW INVOICE <amount> <customer_name>'
+                );
+              }
+              continue;
+            }
+
+            if (upper.startsWith('PAID ')) {
+              const parts = trimmed.split(/\s+/);
+              const code = parts[1];
+              const invoice = await markInvoicePaid(code);
+              const msgText = invoice
+                ? `Invoice ${code} marked as paid.`
+                : `Invoice ${code} not found.`;
+              await sendWhatsAppText(userId, msgText);
+              continue;
+            }
+
+            if (upper === 'UNPAID') {
+              const invoices = await listUnpaidInvoices();
+              if (!invoices.length) {
+                await sendWhatsAppText(userId, 'No unpaid invoices.');
+              } else {
+                const lines = invoices
+                  .map(
+                    (inv) =>
+                      `${inv.invoiceCode} - ${inv.customerName} (${inv.amount})`
+                  )
+                  .join('\n');
+                await sendWhatsAppText(
+                  userId,
+                  `Unpaid invoices:\n${lines}`
+                );
+              }
+              continue;
+            }
+
+            if (upper === 'PAID') {
+              const invoice = await markInvoicePaidByPhone(userId);
+              const msgText = invoice
+                ? `Thanks ${invoice.customerName}, payment received for invoice ${invoice.invoiceCode}.`
+                : 'No pending invoice found.';
+              await sendWhatsAppText(userId, msgText);
+              continue;
+            }
+
             const tag = await LeadCtrl.tagConversation(text);
             console.log('Determined tag:', tag);
 
@@ -104,7 +176,7 @@ class WhatsappController {
               });
             }
           } catch (err) {
-            console.error('Error tagging WhatsApp lead:', err);
+            console.error('Error processing WhatsApp message:', err);
           }
         }
       }


### PR DESCRIPTION
## Summary
- model WhatsApp bot invoices and statuses in Prisma schema
- use Prisma to create and update bot invoices instead of MongoDB

## Testing
- `npx prisma generate`
- `npm test` *(fails: No tests found)*
- `npm run build` *(fails: Namespace '...Prisma' has no exported member 'InvoiceGetPayload', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a08a144ec883218cc919b84bb72064